### PR TITLE
Hyperlink DOI against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SenticNet API
 
-[![Image](https://zenodo.org/badge/doi/10.5281/zenodo.9805.png "DOI") ](http://dx.doi.org/10.5281/zenodo.9805 "DOI")
+[![Image](https://zenodo.org/badge/doi/10.5281/zenodo.9805.png "DOI") ](https://doi.org/10.5281/zenodo.9805 "DOI")
 
 Simple API to use SenticNet 5 (http://sentic.net/).
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. 

In case you used a Python to automatically create the Zenodo badge, could you please let me know which? I'll send a similar patch upstream as well, so they start creating the new DOI links.

Cheers!